### PR TITLE
Make use of constants.py

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,14 +1,10 @@
-from os import environ
 from pathlib import Path
 from sys import stderr
 from traceback import print_exc
 
 from discord.ext import commands
 
-HACKTOBERBOT_TOKEN = environ.get('HACKTOBERBOT_TOKEN')
-
-ghost_unicode = "\N{GHOST}"
-bot = commands.Bot(command_prefix=commands.when_mentioned_or(".", f"{ghost_unicode} ", ghost_unicode))
+bot = commands.Bot(command_prefix=commands.when_mentioned_or(*constants.HACKTOBERBOT_PREFIX)
 
 if __name__ == '__main__':
     # Scan for files in the /cogs/ directory and make a list of the file names.
@@ -20,4 +16,4 @@ if __name__ == '__main__':
             print(f'Failed to load extension {extension}.', file=stderr)
             print_exc()
 
-bot.run(HACKTOBERBOT_TOKEN)
+bot.run(constants.HACKTOBERBOT_TOKEN)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -1,0 +1,5 @@
+from os import environ
+
+ghost_unicode = "\N{GHOST}"
+HACKTOBERBOT_TOKEN = environ.get('HACKTOBERBOT_TOKEN')
+HACKTOBERBOT_PREFIX = environ.get('HACKTOBERBOT_PREFIX', ['.', f'{ghost_unicode} ', ghost_unicode])


### PR DESCRIPTION
This PR changes it so that all constants previously found in the main `bot.py` are now found in the correct place - `constants.py`. It also adds support for setting the bot's prefix through the environment var `HACKTOBERBOT_PREFIX`, but will default to `.`, `👻 `, 👻 if it is not found.