### PR TITLE
Add regex & command prefix filters to reaction cog

### DIFF
--- a/bot/cogs/spookyreact.py
+++ b/bot/cogs/spookyreact.py
@@ -1,11 +1,13 @@
+import re
+
 SPOOKY_TRIGGERS = {
-    'spooky': "\U0001F47B",
-    'skeleton': "\U0001F480",
-    'doot': "\U0001F480",
-    'pumpkin': "\U0001F383",
-    'halloween': "\U0001F383",
-    'jack-o-lantern': "\U0001F383",
-    'danger': "\U00002620"
+    'spooky': (r"\bspo{2,}ky\b", "\U0001F47B"),
+    'skeleton': (r"\bskeleton\b", "\U0001F480"),
+    'doot': (r"\bdo{2,}t\b", "\U0001F480"),
+    'pumpkin': (r"\bpumpkin\b", "\U0001F383"),
+    'halloween': (r"\bhalloween\b", "\U0001F383"),
+    'jack-o-lantern': (r"\bjack-o-lantern\b", "\U0001F383"),
+    'danger': (r"\bdanger\b", "\U00002620")
 }
 
 
@@ -21,10 +23,17 @@ class SpookyReact:
     async def on_message(self, ctx):
         """
         A command to send the hacktoberbot github project
+
+        Lines that begin with the bot's command prefix are ignored
         """
-        for trigger in SPOOKY_TRIGGERS.keys():
-            if trigger in ctx.content.lower():
-                await ctx.add_reaction(SPOOKY_TRIGGERS[trigger])
+        # Check for & ignore messages with bot commands, since we're in on_message
+        # we don't have a Context object, so we need to generate a temporary one
+        tmp_ctx = await self.bot.get_context(ctx)
+        if not tmp_ctx.prefix:
+            for trigger in SPOOKY_TRIGGERS.keys():
+                trigger_test = re.search(SPOOKY_TRIGGERS[trigger][0], ctx.content.lower())
+                if trigger_test:
+                    await ctx.add_reaction(SPOOKY_TRIGGERS[trigger][1])
 
 
 def setup(bot):


### PR DESCRIPTION
- Add a command prefix check to prevent commands from firing the spooky reaction cog
- Translate the spooky reaction check into a regular expression
  - Prevents matching of substrings (e.g. `"halloween"` matching `"halloweenify"`
  - Allows for flexible matching of certain reactions (e.g. `"spoooooky"` fires the `"spooky"` reaction)