### PR TITLE
Fix hacktoberstats to properly parse valid repository names with _ and .

### DIFF
--- a/bot/cogs/hacktoberstats.py
+++ b/bot/cogs/hacktoberstats.py
@@ -22,7 +22,7 @@ class Stats:
         aliases=('hacktoberstats', 'getstats', 'userstats'),
         invoke_without_command=True
     )
-    async def hacktoberstats_group(self, ctx: commands.Context, github_username: str=None):
+    async def hacktoberstats_group(self, ctx: commands.Context, github_username: str = None):
         """
         If invoked without a subcommand or github_username, get the invoking user's stats if
         they've linked their Discord name to GitHub using .stats link
@@ -47,7 +47,7 @@ class Stats:
         await self.get_stats(ctx, github_username)
 
     @hacktoberstats_group.command(name="link")
-    async def link_user(self, ctx: commands.Context, github_username: str=None):
+    async def link_user(self, ctx: commands.Context, github_username: str = None):
         """
         Link the invoking user's Github github_username to their Discord ID
 
@@ -264,7 +264,7 @@ class Stats:
              V
              "discord-python/hacktoberbot"
         """
-        exp = r"https?:\/\/api.github.com\/repos\/([/\-\w]+)"
+        exp = r"https?:\/\/api.github.com\/repos\/([/\-\_\.\w]+)"
         return re.findall(exp, in_url)[0]
 
     @staticmethod


### PR DESCRIPTION
Minor adjustment to the regex used to parse the repository name from the API's return URL so we're properly handling repositories like `discord.py`